### PR TITLE
fix: 調整card max-width

### DIFF
--- a/components/card.ejs
+++ b/components/card.ejs
@@ -1,4 +1,4 @@
-<div class="card product-card border-0" style="max-width: 350px;">
+<div class="card product-card border-0" style="max-width: 416px;">
     <div class="position-relative">
         <a href="#" type="button" class="fw-medium position-absolute top-0  badge rounded-pill bg-primary-100 text-primary fs-6 m-4 px-2 py-1 d-flex justify-content-center align-items-center">
             <img class="me-1" src="/assets/icons/leaf-icon.png" alt="安心認證icon圖示">


### PR DESCRIPTION
1. 因首頁 card 的寬度為 416px，因此 card 的寬度調整對齊最大寬度，不影響商品頁 card 的呈現。